### PR TITLE
Some fixes for MPV compatibility and new dirvish version

### DIFF
--- a/media-progress-dirvish.el
+++ b/media-progress-dirvish.el
@@ -85,7 +85,7 @@
 (defun media-progress-dirvish-setup ()
   "Set up media-progress info segment for DIRVISH."
   (setq media-progress-dirvish-cache (make-hash-table :test 'equal))
-  (push '(media-progress-dirvish media-progress) dirvish-libraries)
+  (push '(media-progress-dirvish media-progress) dirvish--libraries)
   (push 'media-progress dirvish-attributes))
 
 (provide 'media-progress-dirvish)

--- a/media-progress.el
+++ b/media-progress.el
@@ -146,7 +146,8 @@ If you want to check all files - set variable to nil
                             (buffer-string)))
          (wl-lines (split-string wl-file-content "\n"))
          (wl-alist (mapcar #'media-progress--parse-wl-line wl-lines)))
-    (string-to-number (alist-get 'start wl-alist))))
+    (when (alist-get 'start wl-alist)
+        (string-to-number (alist-get 'start wl-alist)))))
 
 (defun media-progress--get-duration (media-file)
   "Get duration of the MEDIA-FILE if mediainfo binary available."
@@ -163,16 +164,16 @@ If you want to check all files - set variable to nil
 Return an empty string if no info found."
   (or (when-let* ((media-p (media-progress--media-p media-file))
                   (wl-file (media-progress--get-watch-later-file media-file)))
-
         ;; current-pos duration completed format-str subst)
-        (let  ((current-pos (media-progress--extract-pos wl-file))
-               (duration (media-progress--get-duration media-file)))
+        (let*  ((current-pos (media-progress--extract-pos wl-file))
+                (duration (when current-pos (media-progress--get-duration media-file))))
           (if duration
               (if (>= (/ (float current-pos) duration) media-progress-completed-threshold) ;completed if t
                   media-progress-completed-message
                 (format media-progress-format (round (* 100 (/ (float current-pos) duration)))))
-            (format media-progress-fallback-format
-                    (format-seconds media-progress-watched-time-format current-pos)))))
+            (when current-pos
+              (format media-progress-fallback-format
+                      (format-seconds media-progress-watched-time-format current-pos))))))
       ""))
 
 (provide 'media-progress)


### PR DESCRIPTION
Hello,

I updated the package on my side to fix a few issues:
  - dirvish change the variable name `dirvish-libraries` to `dirvish--libraries`
  - my mpv seems to add additional info in the watch_later file and so this file doesn't necessarily contains a "start" field. I updated the package to ignore this type of watch_later file